### PR TITLE
feat: Add voice channel event logging and `$voicelogs` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ docker build -t discord-bot . && docker run --env-file bot.env -d -p 8080:8080 -
 
 -   `$dashboard`: The bot will reply with a link to the web dashboard for the current server.
 
+-   `$voicelogs`: Shows a log of users joining and leaving voice channels in the last 24 hours.
+
 ## Music Commands
 
 -   `$play <youtube_url_or_search>`: Plays a song from a YouTube URL or search query. If a song is already playing, it adds the new song to the queue.


### PR DESCRIPTION
This commit introduces a new feature to log and display voice channel join/leave events.

- **Database Update:** A new `voice_events` table has been added to `database.py` to store individual join/leave events with user, channel, and timestamp information.
- **Enhanced Logging:** The `on_voice_state_update` event handler in `bot.py` has been updated to call the new `log_voice_event` function, capturing detailed event data.
- **New Command:** A new `$voicelogs` command has been implemented in `bot.py`. This command retrieves the last 24 hours of voice events from the database and displays them in a formatted embed.
- **Documentation:** The `README.md` file has been updated to include the new `$voicelogs` command.