### PR TITLE
fix: Use environment variable for dashboard host IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,18 @@ Before you can run the project, you need to create a Discord bot application and
     git clone <repository-url>
     cd <repository-directory>
     ```
-2.  **Create the `bot.env` file:**
-    Create a file named `bot.env` in the root of the project. Add your Discord bot token that you obtained in the previous step to this file:
+2.  **Create and configure the `bot.env` file:**
+    Create a file named `bot.env` in the root of the project. This file holds the configuration for your bot.
+    You need to add two variables:
     ```
+    # Your bot's secret token from the Discord Developer Portal
     DISCORD_TOKEN=YOUR_DISCORD_BOT_TOKEN
+
+    # The public IP address of your server (e.g., 123.45.67.89)
+    # This is needed for the $dashboard command to generate correct links.
+    BOT_HOST_IP=your_server_ip
     ```
+    Replace `YOUR_DISCORD_BOT_TOKEN` and `your_server_ip` with your actual values.
 
 ## Running the Bot
 

--- a/bot.env
+++ b/bot.env
@@ -1,3 +1,6 @@
 # Replace YOUR_DISCORD_BOT_TOKEN with your actual bot token.
-# This file is used by the Docker container to load your bot's token.
 DISCORD_TOKEN=YOUR_DISCORD_BOT_TOKEN
+
+# Replace your_server_ip with the public IP address of your VPS or server.
+# This is used to generate correct links for the web dashboard.
+BOT_HOST_IP=your_server_ip

--- a/bot.py
+++ b/bot.py
@@ -102,8 +102,15 @@ async def ping(ctx):
 @bot.command(name='dashboard', help='Get a link to the web dashboard.')
 async def dashboard(ctx):
     if ctx.guild:
-        dashboard_url = f"http://localhost:8080/dashboard/{ctx.guild.id}"
-        await ctx.send(f"You can view the server dashboard here: {dashboard_url}")
+        # Use the BOT_HOST_IP from environment variables, defaulting to localhost
+        host_ip = os.getenv('BOT_HOST_IP', 'localhost')
+        dashboard_url = f"http://{host_ip}:8080/dashboard/{ctx.guild.id}"
+
+        message = f"You can view the server dashboard here: {dashboard_url}"
+        if host_ip == 'localhost':
+            message += "\n\n**Note:** The link uses `localhost`. For public access, please set the `BOT_HOST_IP` environment variable in your `bot.env` file."
+
+        await ctx.send(message)
     else:
         await ctx.send("This command can only be used in a server.")
 


### PR DESCRIPTION
This commit fixes an issue where the `$dashboard` command would always generate a URL with `localhost` instead of the server's public IP address.

- The `$dashboard` command in `bot.py` has been updated to use a new environment variable, `BOT_HOST_IP`, to construct the URL. It defaults gracefully to `localhost` and provides an informational message if the variable is not set.
- The `bot.env` file has been updated to include `BOT_HOST_IP` as a configurable variable.
- The `README.md` has been updated to document this new variable and explain how to configure it.