### PR TITLE
fix: Refactor webapp to fix RuntimeError from cross-thread async calls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py
-Flask[async]
+Flask
 matplotlib
 yt-dlp
 PyNaCl


### PR DESCRIPTION
This commit resolves a `RuntimeError: Timeout context manager should be used inside a task` that occurred when the Flask web server (running in a separate thread) attempted to directly `await` a coroutine from the bot's main event loop.

The `webapp.py` has been refactored to:
- Convert the `dashboard` view function from `async def` to a standard `def`.
- Use `asyncio.run_coroutine_threadsafe` to safely delegate the asynchronous `guild.fetch_member` call to the bot's event loop. This is the correct and robust way to handle cross-thread asyncio operations.
- The `Flask[async]` dependency has been reverted to `Flask` in `requirements.txt` as it is no longer required for the synchronous view.

This change ensures the stability and correctness of the web dashboard.