### PR TITLE
feat: Add auto-responder for settings questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project provides a Discord bot with a web dashboard that can be easily depl
 -   **Daily Member Count**: Tracks the server's member count daily.
 -   **Web Dashboard**: A web page to visualize server statistics, including a member count graph and a leaderboard of the most active users.
 -   **Music Playback**: Play music from YouTube by providing a URL or search query.
+-   **Auto-Responder**: Automatically replies to questions about settings, directing users to a designated channel.
 -   **Dockerized**: Runs both the bot and the web server in a single container.
 
 ## Prerequisites
@@ -53,7 +54,7 @@ Before you can run the project, you need to create a Discord bot application and
     ```
 2.  **Create and configure the `bot.env` file:**
     Create a file named `bot.env` in the root of the project. This file holds the configuration for your bot.
-    You need to add two variables:
+    You need to add the following variables:
     ```
     # Your bot's secret token from the Discord Developer Portal
     DISCORD_TOKEN=YOUR_DISCORD_BOT_TOKEN
@@ -61,8 +62,12 @@ Before you can run the project, you need to create a Discord bot application and
     # The public IP address of your server (e.g., 123.45.67.89)
     # This is needed for the $dashboard command to generate correct links.
     BOT_HOST_IP=your_server_ip
+
+    # (Optional) The ID of the channel where users should be redirected for settings info.
+    # The bot will reply to questions about settings and point to this channel.
+    SETTINGS_INFO_CHANNEL_ID=1229938413709557900
     ```
-    Replace `YOUR_DISCORD_BOT_TOKEN` and `your_server_ip` with your actual values.
+    Replace the placeholder values with your actual data.
 
 ## Running the Bot
 

--- a/bot.env
+++ b/bot.env
@@ -8,3 +8,7 @@ BOT_HOST_IP=your_server_ip
 # (Optional) Path to the YouTube cookies file inside the container.
 # This is needed if YouTube starts blocking downloads. See README for instructions.
 YOUTUBE_COOKIE_PATH=/app/cookies.txt
+
+# (Optional) The ID of the channel where users should be redirected for settings info.
+# The bot will reply to questions about settings and point to this channel.
+SETTINGS_INFO_CHANNEL_ID=1229938413709557900

--- a/bot.py
+++ b/bot.py
@@ -67,12 +67,20 @@ async def on_ready():
 
 @bot.event
 async def on_message(message):
-    """Called for every message. Logs messages for stats and processes commands."""
+    """Called for every message. Logs messages, checks for auto-responses, and processes commands."""
     if message.author.bot:
         return
+
+    # First, log the message for statistics
     if message.guild:
         database.log_message(message.author.id, message.guild.id)
-    # This is crucial to ensure that command decorators work
+
+    # Then, check if the auto-responder cog should handle this message
+    auto_responder_cog = bot.get_cog('AutoResponder')
+    if auto_responder_cog:
+        await auto_responder_cog.check_for_response(message)
+
+    # Finally, process any potential commands in the message
     await bot.process_commands(message)
 
 @bot.event

--- a/cogs/auto_responder.py
+++ b/cogs/auto_responder.py
@@ -1,0 +1,64 @@
+import discord
+from discord.ext import commands
+import os
+
+# Expanded keyword lists for better detection
+TOPIC_KEYWORDS = [
+    'celownik', 'czułość', 'dpi', 'myszka', 'grafika',
+    'ustawienia graficzne', 'rozdziałka', 'rozdzielczość',
+    'stretch', 'stretched', 'rozciągnięta', 'config', 'cfg',
+    'resolution', 'crosshair', 'sensitivity', 'sens'
+]
+
+QUESTION_WORDS = [
+    'jak', 'gdzie', 'ktoś', 'ma ktoś', 'poda', 'podeśle', 'podeślesz',
+    'jaki', 'jaka', 'jakie', 'czy', 'pomocy', 'pytanie', 'pomoże',
+    'macie', 'ustawić', 'zmienić', 'polecacie'
+]
+
+class AutoResponder(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        try:
+            self.target_channel_id = int(os.getenv('SETTINGS_INFO_CHANNEL_ID'))
+            print(f"Auto-responder loaded. Target channel ID: {self.target_channel_id}")
+        except (TypeError, ValueError):
+            self.target_channel_id = None
+            print("WARNING: SETTINGS_INFO_CHANNEL_ID is not set or invalid. Auto-responder is disabled.")
+
+    async def check_for_response(self, message):
+        """Checks a message and sends an auto-response if it matches criteria."""
+        # Ignore if the feature is disabled, if the message is from a bot, or if it's in the target channel
+        if not self.target_channel_id or message.author.bot or message.channel.id == self.target_channel_id:
+            return
+
+        message_content_lower = message.content.lower()
+
+        # Check if the message contains any of the relevant topic keywords
+        has_topic_keyword = any(keyword in message_content_lower for keyword in TOPIC_KEYWORDS)
+
+        if not has_topic_keyword:
+            return
+
+        # Check if the message is likely a question
+        is_a_question = False
+        if message_content_lower.endswith('?'):
+            is_a_question = True
+        if not is_a_question and any(q_word in message_content_lower.split() for q_word in QUESTION_WORDS):
+            is_a_question = True
+
+        if is_a_question:
+            try:
+                reply_message = (
+                    f"Cześć, {message.author.mention}! Widzę, że pytasz o ustawienia.\n"
+                    f"Wszystkie potrzebne informacje, takie jak configi, celowniki czy ustawienia 'true stretched', znajdziesz na kanale <#{self.target_channel_id}>."
+                )
+                await message.reply(reply_message, mention_author=False)
+                print(f"Auto-responded to a settings question from {message.author}.")
+            except discord.errors.Forbidden:
+                print(f"Could not reply to {message.author} in channel {message.channel.id}. Missing permissions.")
+            except Exception as e:
+                print(f"An error occurred in auto-responder: {e}")
+
+async def setup(bot):
+    await bot.add_cog(AutoResponder(bot))


### PR DESCRIPTION
This commit introduces a new feature that allows the bot to automatically reply to user questions about settings and direct them to a specific channel.

- **New Auto-Responder Cog:** A new cog, `cogs/auto_responder.py`, has been created to house all the logic for this feature. It uses a combination of topic-based and question-based keywords to detect relevant messages.
- **Centralized Event Handling:** The logic has been integrated into the main `on_message` event in `bot.py` to avoid duplicate event listeners and ensure a robust design.
- **Configurable Channel:** The target channel for the redirection is configurable via a new `SETTINGS_INFO_CHANNEL_ID` environment variable.
- **Updated Documentation:** The `README.md` and `bot.env` template have been updated to include instructions for this new feature and its configuration.