### PR TITLE
feat: Add seeding capability for the dynamic auto-responder

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,6 @@ Before you can run the project, you need to create a Discord bot application and
     # The public IP address of your server (e.g., 123.45.67.89)
     # This is needed for the $dashboard command to generate correct links.
     BOT_HOST_IP=your_server_ip
-
-    # (Optional) The ID of the channel where users should be redirected for settings info.
-    # The bot will reply to questions about settings and point to this channel.
-    SETTINGS_INFO_CHANNEL_ID=1229938413709557900
     ```
     Replace the placeholder values with your actual data.
 
@@ -99,6 +95,22 @@ docker build -t discord-bot . && docker run --env-file bot.env -d -p 8080:8080 -
 -   `$voicelogs`: Shows a log of users joining and leaving voice channels in the last 24 hours.
 
 -   `$debug`: Runs and displays a report of diagnostic checks, such as the status of the YouTube cookie file.
+
+## Auto-Responder Commands
+
+The auto-responder feature is fully configurable via commands. These commands are only available to users with **Administrator** permissions. The main command group is `$ar`.
+
+-   `$ar list`: Shows the current configuration for the auto-responder, including its status, target channel, reply message, and all keywords.
+-   `$ar toggle`: Enables or disables the auto-responder on the server.
+-   `$ar channel <#channel>`: Sets the text channel where users will be redirected.
+-   `$ar message <your custom message>`: Sets the reply message. You must include `{mention}` and `{channel}` placeholders, which will be replaced with the user's mention and the target channel link, respectively.
+-   `$ar add <type> <keyword>`: Adds a new keyword.
+    -   **type**: Must be `topic` or `question`.
+    -   **keyword**: The word or phrase to add.
+-   `$ar remove <type> <keyword>`: Removes a keyword.
+    -   **type**: Must be `topic` or `question`.
+    -   **keyword**: The word or phrase to remove.
+-   `$ar seed`: Populates the keyword lists with a recommended default set of keywords to get you started quickly.
 
 ## Music Commands
 

--- a/bot.env
+++ b/bot.env
@@ -8,7 +8,3 @@ BOT_HOST_IP=your_server_ip
 # (Optional) Path to the YouTube cookies file inside the container.
 # This is needed if YouTube starts blocking downloads. See README for instructions.
 YOUTUBE_COOKIE_PATH=/app/cookies.txt
-
-# (Optional) The ID of the channel where users should be redirected for settings info.
-# The bot will reply to questions about settings and point to this channel.
-SETTINGS_INFO_CHANNEL_ID=1229938413709557900

--- a/cogs/auto_responder.py
+++ b/cogs/auto_responder.py
@@ -1,41 +1,42 @@
 import discord
 from discord.ext import commands
 import os
-
-# Expanded keyword lists for better detection
-TOPIC_KEYWORDS = [
-    'celownik', 'czułość', 'dpi', 'myszka', 'grafika',
-    'ustawienia graficzne', 'rozdziałka', 'rozdzielczość',
-    'stretch', 'stretched', 'rozciągnięta', 'config', 'cfg',
-    'resolution', 'crosshair', 'sensitivity', 'sens'
-]
-
-QUESTION_WORDS = [
-    'jak', 'gdzie', 'ktoś', 'ma ktoś', 'poda', 'podeśle', 'podeślesz',
-    'jaki', 'jaka', 'jakie', 'czy', 'pomocy', 'pytanie', 'pomoże',
-    'macie', 'ustawić', 'zmienić', 'polecacie'
-]
+import database # Import our database module
 
 class AutoResponder(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        try:
-            self.target_channel_id = int(os.getenv('SETTINGS_INFO_CHANNEL_ID'))
-            print(f"Auto-responder loaded. Target channel ID: {self.target_channel_id}")
-        except (TypeError, ValueError):
-            self.target_channel_id = None
-            print("WARNING: SETTINGS_INFO_CHANNEL_ID is not set or invalid. Auto-responder is disabled.")
+        print("Auto-responder cog loaded.")
 
     async def check_for_response(self, message):
-        """Checks a message and sends an auto-response if it matches criteria."""
-        # Ignore if the feature is disabled, if the message is from a bot, or if it's in the target channel
-        if not self.target_channel_id or message.author.bot or message.channel.id == self.target_channel_id:
+        """Checks a message and sends an auto-response if it matches the guild's dynamic criteria."""
+        if not message.guild:
+            return
+
+        # Fetch the auto-responder configuration for this specific guild
+        config = database.get_ar_config(message.guild.id)
+
+        # The feature must be enabled and have a target channel set
+        if not config or not config['is_enabled'] or not config['target_channel_id']:
+            return
+
+        # Avoid replying to messages in the target channel itself
+        if message.channel.id == config['target_channel_id']:
+            return
+
+        # Fetch keywords for this guild
+        keywords_from_db = database.get_ar_keywords(message.guild.id)
+        topic_keywords = [row['keyword'] for row in keywords_from_db if row['keyword_type'] == 'topic']
+        question_keywords = [row['keyword'] for row in keywords_from_db if row['keyword_type'] == 'question']
+
+        # If no keywords are set, do nothing
+        if not topic_keywords or not question_keywords:
             return
 
         message_content_lower = message.content.lower()
 
         # Check if the message contains any of the relevant topic keywords
-        has_topic_keyword = any(keyword in message_content_lower for keyword in TOPIC_KEYWORDS)
+        has_topic_keyword = any(keyword in message_content_lower for keyword in topic_keywords)
 
         if not has_topic_keyword:
             return
@@ -44,21 +45,115 @@ class AutoResponder(commands.Cog):
         is_a_question = False
         if message_content_lower.endswith('?'):
             is_a_question = True
-        if not is_a_question and any(q_word in message_content_lower.split() for q_word in QUESTION_WORDS):
+        if not is_a_question and any(q_word in message_content_lower.split() for q_word in question_keywords):
             is_a_question = True
 
         if is_a_question:
             try:
-                reply_message = (
-                    f"Cześć, {message.author.mention}! Widzę, że pytasz o ustawienia.\n"
-                    f"Wszystkie potrzebne informacje, takie jak configi, celowniki czy ustawienia 'true stretched', znajdziesz na kanale <#{self.target_channel_id}>."
+                # Format the custom reply message from the database
+                reply_message = config['reply_message'].format(
+                    mention=message.author.mention,
+                    channel=f"<#{config['target_channel_id']}>"
                 )
                 await message.reply(reply_message, mention_author=False)
-                print(f"Auto-responded to a settings question from {message.author}.")
+                print(f"Auto-responded to a settings question from {message.author} in guild {message.guild.id}.")
             except discord.errors.Forbidden:
                 print(f"Could not reply to {message.author} in channel {message.channel.id}. Missing permissions.")
             except Exception as e:
                 print(f"An error occurred in auto-responder: {e}")
+
+    # --- Management Commands for Auto-Responder ---
+    @commands.group(name='ar', invoke_without_command=True)
+    @commands.has_permissions(administrator=True)
+    async def ar(self, ctx):
+        """Manages the auto-responder feature. Use `$ar help` for a list of commands."""
+        await ctx.send("Invalid subcommand. Use `$ar list` to see the current configuration or `$ar help` for commands.")
+
+    @ar.command(name='toggle')
+    @commands.has_permissions(administrator=True)
+    async def ar_toggle(self, ctx):
+        """Enables or disables the auto-responder for this server."""
+        config = database.get_ar_config(ctx.guild.id)
+        new_state = not config['is_enabled']
+        database.set_ar_enabled(ctx.guild.id, new_state)
+        await ctx.send(f"✅ Auto-responder has been **{'enabled' if new_state else 'disabled'}**.")
+
+    @ar.command(name='channel')
+    @commands.has_permissions(administrator=True)
+    async def ar_channel(self, ctx, channel: discord.TextChannel):
+        """Sets the channel where users will be redirected."""
+        database.set_ar_channel(ctx.guild.id, channel.id)
+        await ctx.send(f"✅ Auto-responder will now redirect users to {channel.mention}.")
+
+    @ar.command(name='message')
+    @commands.has_permissions(administrator=True)
+    async def ar_message(self, ctx, *, message: str):
+        """Sets the custom reply message. Use {mention} and {channel}."""
+        if '{mention}' not in message or '{channel}' not in message:
+            await ctx.send("❌ Error: The message must contain both `{mention}` and `{channel}` placeholders.")
+            return
+        database.set_ar_message(ctx.guild.id, message)
+        await ctx.send("✅ Auto-responder message has been updated.")
+
+    @ar.command(name='add')
+    @commands.has_permissions(administrator=True)
+    async def ar_add(self, ctx, keyword_type: str, *, keyword: str):
+        """Adds a keyword. Type must be 'topic' or 'question'."""
+        keyword_type = keyword_type.lower()
+        if keyword_type not in ['topic', 'question']:
+            await ctx.send("❌ Invalid keyword type. Must be `topic` or `question`.")
+            return
+
+        if database.add_ar_keyword(ctx.guild.id, keyword_type, keyword):
+            await ctx.send(f"✅ Added `{keyword}` to the `{keyword_type}` keyword list.")
+        else:
+            await ctx.send(f"⚠️ The keyword `{keyword}` is already in the `{keyword_type}` list.")
+
+    @ar.command(name='remove')
+    @commands.has_permissions(administrator=True)
+    async def ar_remove(self, ctx, keyword_type: str, *, keyword: str):
+        """Removes a keyword. Type must be 'topic' or 'question'."""
+        keyword_type = keyword_type.lower()
+        if keyword_type not in ['topic', 'question']:
+            await ctx.send("❌ Invalid keyword type. Must be `topic` or `question`.")
+            return
+
+        if database.remove_ar_keyword(ctx.guild.id, keyword_type, keyword):
+            await ctx.send(f"✅ Removed `{keyword}` from the `{keyword_type}` keyword list.")
+        else:
+            await ctx.send(f"❌ The keyword `{keyword}` was not found in the `{keyword_type}` list.")
+
+    @ar.command(name='list')
+    @commands.has_permissions(administrator=True)
+    async def ar_list(self, ctx):
+        """Lists the current auto-responder configuration."""
+        config = database.get_ar_config(ctx.guild.id)
+        keywords = database.get_ar_keywords(ctx.guild.id)
+
+        topic_keywords = [f"`{row['keyword']}`" for row in keywords if row['keyword_type'] == 'topic']
+        question_keywords = [f"`{row['keyword']}`" for row in keywords if row['keyword_type'] == 'question']
+
+        embed = discord.Embed(title="Auto-Responder Configuration", color=discord.Color.blue(), description=f"**Status:** {'🟢 Enabled' if config['is_enabled'] else '🔴 Disabled'}")
+
+        channel_mention = f"<#{config['target_channel_id']}>" if config['target_channel_id'] else "Not Set"
+        embed.add_field(name="Target Channel", value=channel_mention, inline=False)
+
+        embed.add_field(name="Reply Message", value=f"```\n{config['reply_message']}\n```", inline=False)
+
+        embed.add_field(name="Topic Keywords", value=", ".join(topic_keywords) if topic_keywords else "None set", inline=False)
+        embed.add_field(name="Question Keywords", value=", ".join(question_keywords) if question_keywords else "None set", inline=False)
+
+        await ctx.send(embed=embed)
+
+    @ar.command(name='seed')
+    @commands.has_permissions(administrator=True)
+    async def ar_seed(self, ctx):
+        """Populates the keyword lists with a default set of values."""
+        added_count = database.seed_default_ar_keywords(ctx.guild.id)
+        if added_count > 0:
+            await ctx.send(f"✅ Successfully seeded the database with {added_count} default keywords.")
+        else:
+            await ctx.send("⚠️ The database already contains all default keywords. No new keywords were added.")
 
 async def setup(bot):
     await bot.add_cog(AutoResponder(bot))


### PR DESCRIPTION
This commit adds a new `$ar seed` command that allows an administrator to populate the auto-responder's keyword lists with a default set of values.

- **New Database Seeding Function:** A `seed_default_ar_keywords` function has been added to `database.py`. It contains the original hardcoded keyword lists and inserts them into the database for a given guild.
- **New `$ar seed` Command:** The `cogs/auto_responder.py` cog now has a `seed` subcommand within the `$ar` group. This command provides an easy, one-time setup for the auto-responder keywords.
- **Updated Documentation:** The `README.md` has been updated to include instructions for the new `$ar seed` command.

This feature provides the flexibility of a fully dynamic system with the convenience of a pre-configured default state.