### PR TITLE
Fix: Resolve ChannelNotFound error in AR command

### DIFF
--- a/cogs/auto_responder.py
+++ b/cogs/auto_responder.py
@@ -80,7 +80,7 @@ class AutoResponder(commands.Cog):
 
     @ar.command(name='channel')
     @commands.has_permissions(administrator=True)
-    async def ar_channel(self, ctx, channel: discord.TextChannel):
+    async def ar_channel(self, ctx, channel: discord.abc.GuildChannel):
         """Sets the channel where users will be redirected."""
         database.set_ar_channel(ctx.guild.id, channel.id)
         await ctx.send(f"✅ Auto-responder will now redirect users to {channel.mention}.")


### PR DESCRIPTION
The `$ar channel` command was raising a `ChannelNotFound` error because its type hint was restricted to `discord.TextChannel`, preventing it from recognizing other channel types.

This has been fixed by changing the type hint to `discord.abc.GuildChannel`, which allows the command to accept any valid channel on the server.

Additionally, the auto-responder's database functions have been strengthened. An `INSERT OR IGNORE` statement was added to `set_ar_enabled`, `set_ar_channel`, and `set_ar_message` to ensure a settings row exists before an update is attempted, preventing potential errors on new server setups.